### PR TITLE
flush

### DIFF
--- a/udisksvm-1.0.sh
+++ b/udisksvm-1.0.sh
@@ -51,9 +51,9 @@ while ps -p $COPROC_PID &>/dev/null; do
 		echo "------------ $event --------------"
 		if [[ "$systeminternal" == "0" ]] && [[ "$usage" == "filesystem" ]] && [[ "$partition" == "1" ]]; then
 		    if [[ "$type" == "vfat" ]]; then
-			options="sync,noatime,nodiratime,noexec,utf8=0"
+			options="flush,noatime,nodiratime,noexec,utf8=0"
 		    else
-			options="sync,noatime,nodiratime,noexec"
+			options="flush,noatime,nodiratime,noexec"
 		    fi
 		    if ! pgrep -f "traydevice $devpath" &>/dev/null; then
 			udisks --mount $devpath --mount-options $options &>/dev/null


### PR DESCRIPTION
sync makes my usb sticks very slow. 
as the mount manpage states:
sync   All  I/O  to  the  filesystem  should  be  done synchronously. In case of media with limited number of write cycles (e.g. some flash drives) "sync" may cause life-cycle shortening.
flush  If set, the filesystem will try to flush to disk more early than normal.  Not set by default.

Seems that should be flush instead of sync (form user perspective no diff)
To test speed you can use:
dd if=/dev/zero of=/media/{media}/test.img bs=8k count=8k
it'll write 64MB file filled with zeros.

In my case sync was at about 800 kb/s and flush about 18 MB/s 
